### PR TITLE
Migrate circileci 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2.1
+executors:
+  node:
+    docker:
+      - image: circleci/node:8.16.1
+jobs:
+  prepare-deps:
+    executor: node
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - persist_to_workspace:
+          root: .
+          paths:
+            - node_modules
+  test:
+    executor: node
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Run tests
+          command: npm test
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - prepare-deps
+      - test:
+          requires:
+            - prepare-deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-hd-keyring",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
CircleCI requires that we migrate to v2.0 of their config format. The new config format must be in the `.circleci` directory, and doesn't have any implicit steps anymore (e.g. the `test` step is now explicit).

The lockfile has also been updated.