### PR TITLE
Add typed methods via inheritance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events').EventEmitter
 const hdkey = require('ethereumjs-wallet/hdkey')
 const Wallet = require('ethereumjs-wallet')
+const SimpleKeyring = require('eth-simple-keyring')
 const bip39 = require('bip39')
 const ethUtil = require('ethereumjs-util')
 const sigUtil = require('eth-sig-util')
@@ -9,10 +10,9 @@ const sigUtil = require('eth-sig-util')
 const hdPathString = `m/44'/60'/0'/0`
 const type = 'HD Key Tree'
 
-class HdKeyring extends EventEmitter {
+class HdKeyring extends SimpleKeyring {
 
   /* PUBLIC METHODS */
-
   constructor (opts = {}) {
     super()
     this.type = type
@@ -98,14 +98,6 @@ class HdKeyring extends EventEmitter {
     return Promise.resolve(sig)
   }
 
-  // personal_signTypedData, signs data along with the schema
-  signTypedData (withAccount, typedData, opts = {}) {
-    const wallet = this._getWalletForAccount(withAccount, opts)
-    const privKey = ethUtil.toBuffer(wallet.getPrivateKey())
-    const signature = sigUtil.signTypedData(privKey, { data: typedData })
-    return Promise.resolve(signature)
-  }
-
   // For eth_sign, we need to sign transactions:
   newGethSignMessage (withAccount, msgHex, opts = {}) {
     const wallet = this._getWalletForAccount(withAccount, opts)
@@ -167,6 +159,16 @@ class HdKeyring extends EventEmitter {
 
     return wallet
   }
+
+  getPrivateKeyFor (address, opts = {}) {
+    if (!address) {
+      throw new Error('Must specify address.');
+    }
+    const wallet = this._getWalletForAccount(address, opts)
+    const privKey = ethUtil.toBuffer(wallet.getPrivateKey())
+    return privKey;
+  }
+
 }
 
 HdKeyring.type = type

--- a/index.js
+++ b/index.js
@@ -70,65 +70,10 @@ class HdKeyring extends SimpleKeyring {
     }))
   }
 
-  // tx is an instance of the ethereumjs-transaction class.
-  signTransaction (address, tx, opts = {}) {
-    const wallet = this._getWalletForAccount(address, opts)
-    var privKey = wallet.getPrivateKey()
-    tx.sign(privKey)
-    return Promise.resolve(tx)
-  }
-
-  // For eth_sign, we need to sign transactions:
-  // hd
-  signMessage (withAccount, data, opts = {}) {
-    const wallet = this._getWalletForAccount(withAccount, opts)
-    const message = ethUtil.stripHexPrefix(data)
-    var privKey = wallet.getPrivateKey()
-    var msgSig = ethUtil.ecsign(new Buffer(message, 'hex'), privKey)
-    var rawMsgSig = ethUtil.bufferToHex(sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s))
-    return Promise.resolve(rawMsgSig)
-  }
-
-  // For personal_sign, we need to prefix the message:
-  signPersonalMessage (withAccount, msgHex, opts = {}) {
-    const wallet = this._getWalletForAccount(withAccount, opts)
-    const privKey = ethUtil.stripHexPrefix(wallet.getPrivateKey())
-    const privKeyBuffer = new Buffer(privKey, 'hex')
-    const sig = sigUtil.personalSign(privKeyBuffer, { data: msgHex })
-    return Promise.resolve(sig)
-  }
-
-  // For eth_sign, we need to sign transactions:
-  newGethSignMessage (withAccount, msgHex, opts = {}) {
-    const wallet = this._getWalletForAccount(withAccount, opts)
-    const privKey = wallet.getPrivateKey()
-    const msgBuffer = ethUtil.toBuffer(msgHex)
-    const msgHash = ethUtil.hashPersonalMessage(msgBuffer)
-    const msgSig = ethUtil.ecsign(msgHash, privKey)
-    const rawMsgSig = ethUtil.bufferToHex(sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s))
-    return Promise.resolve(rawMsgSig)
-  }
-
-  // returns an app key
-  getAppKeyAddress (address, origin) {
-    return new Promise((resolve, reject) => {
-      try {
-        const wallet = this._getWalletForAccount(address, {
-          withAppKeyOrigin: origin,
-        })
-        const appKeyAddress = sigUtil.normalize(wallet.getAddress().toString('hex'))
-        return resolve(appKeyAddress)
-      } catch (e) {
-        return reject(e)
-      }
-    })
-  }
-
   exportAccount (address) {
     const wallet = this._getWalletForAccount(address)
     return Promise.resolve(wallet.getPrivateKey().toString('hex'))
   }
-
 
   /* PRIVATE METHODS */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,11 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
       "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bignumber.js": {
       "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
       "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
@@ -121,6 +126,15 @@
       "requires": {
         "bs58": "^3.1.0",
         "create-hash": "^1.1.0"
+      }
+    },
+    "buffer": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.2.tgz",
+      "integrity": "sha512-iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-xor": {
@@ -245,38 +259,16 @@
       "dev": true
     },
     "eth-sig-util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.0.1.tgz",
-      "integrity": "sha512-lxHZOQspexk3DaGj4RBbWy4C/qNOWRnxpaJzNnYD3WEmC8shcJ4tHs7Xv878rzvILfJnSFSCCiKQhng1m80oBQ==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.4.4.tgz",
+      "integrity": "sha512-iWGqEJwsUMgtk8AqQQqIDTjMz+pW8s2Sq8gN640dh9U9HoEFQJO3m6ro96DgV6hMB2LYu8F5812LQyynOgCbEw==",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-        "ethereumjs-util": "^5.1.1"
-      },
-      "dependencies": {
-        "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-          "requires": {
-            "bn.js": "^4.11.8",
-            "ethereumjs-util": "^6.0.0"
-          },
-          "dependencies": {
-            "ethereumjs-util": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-              "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
-              "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "ethjs-util": "0.1.6",
-                "keccak": "^1.0.2",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
-              }
-            }
-          }
-        }
+        "buffer": "^5.2.1",
+        "elliptic": "^6.4.0",
+        "ethereumjs-abi": "0.6.5",
+        "ethereumjs-util": "^5.1.1",
+        "tweetnacl": "^1.0.0",
+        "tweetnacl-util": "^0.15.0"
       }
     },
     "ethereumjs-abi": {
@@ -453,6 +445,11 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -777,6 +774,16 @@
       "requires": {
         "has-flag": "^1.0.0"
       }
+    },
+    "tweetnacl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+      "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
+    },
+    "tweetnacl-util": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.0.tgz",
+      "integrity": "sha1-RXbBzuXi1j0gf+5S8boCgZSAvHU="
     },
     "unorm": {
       "version": "1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-hd-keyring",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -269,6 +269,19 @@
         "ethereumjs-util": "^5.1.1",
         "tweetnacl": "^1.0.0",
         "tweetnacl-util": "^0.15.0"
+      }
+    },
+    "eth-simple-keyring": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eth-simple-keyring/-/eth-simple-keyring-3.1.0.tgz",
+      "integrity": "sha512-j7S9XftI112+ZuicIdFEMqovYjgOHDBb+LKnI39iaxpkp1LEgdkmo0Ly1KHeFVlNDIgzpU47gLqKK6V+86XdAg==",
+      "requires": {
+        "eth-sig-util": "^2.4.3",
+        "ethereumjs-abi": "^0.6.5",
+        "ethereumjs-util": "^5.1.1",
+        "ethereumjs-wallet": "^0.6.0",
+        "events": "^1.1.1",
+        "xtend": "^4.0.1"
       }
     },
     "ethereumjs-abi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-hd-keyring",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A simple standard interface for a seed phrase generated set of Ethereum accounts.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-hd-keyring",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A simple standard interface for a seed phrase generated set of Ethereum accounts.",
   "main": "index.js",
   "scripts": {
@@ -23,6 +23,7 @@
   "dependencies": {
     "bip39": "^2.2.0",
     "eth-sig-util": "^2.4.4",
+    "eth-simple-keyring": "^3.1.0",
     "ethereumjs-abi": "^0.6.5",
     "ethereumjs-util": "^5.1.1",
     "ethereumjs-wallet": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/MetaMask/eth-hd-keyring#readme",
   "dependencies": {
     "bip39": "^2.2.0",
-    "eth-sig-util": "^2.0.1",
+    "eth-sig-util": "^2.4.4",
     "ethereumjs-abi": "^0.6.5",
     "ethereumjs-util": "^5.1.1",
     "ethereumjs-wallet": "^0.6.0",


### PR DESCRIPTION
Now uses inheritance to reuse method implementations from [eth-simple-keyring](https://github.com/MetaMask/eth-simple-keyring), by merely exposing a `getPrivateKeyFor(address)` method.

Adds methods for all the types of `signTypedData` methods, with tests included, and confirms those signed results can be recovered with the latest [eth-sig-util](https://github.com/MetaMask/eth-sig-util).

Includes the same breaking change as [eth-simple-keyring has](https://github.com/MetaMask/eth-simple-keyring/pull/20), because `signTypedData` now directs to the `_v1` method instead of `_v3`, to match the MetaMask provider API.