### PR TITLE
Version 3.4.1: Remove inherited methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,11 +70,6 @@ class HdKeyring extends SimpleKeyring {
     }))
   }
 
-  exportAccount (address) {
-    const wallet = this._getWalletForAccount(address)
-    return Promise.resolve(wallet.getPrivateKey().toString('hex'))
-  }
-
   /* PRIVATE METHODS */
 
   _initFromMnemonic (mnemonic) {
@@ -83,37 +78,6 @@ class HdKeyring extends SimpleKeyring {
     this.hdWallet = hdkey.fromMasterSeed(seed)
     this.root = this.hdWallet.derivePath(this.hdPath)
   }
-
-
-  _getWalletForAccount (account, opts = {}) {
-    const targetAddress = sigUtil.normalize(account)
-
-    let wallet = this.wallets.find((w) => {
-      const address = sigUtil.normalize(w.getAddress().toString('hex'))
-      return ((address === targetAddress) ||
-              (sigUtil.normalize(address) === targetAddress))
-    })
-
-    if (opts.withAppKeyOrigin) {
-      const privKey = wallet.getPrivateKey()
-      const appKeyOriginBuffer = Buffer.from(opts.withAppKeyOrigin, 'utf8')
-      const appKeyBuffer = Buffer.concat([privKey, appKeyOriginBuffer])
-      const appKeyPrivKey = ethUtil.keccak(appKeyBuffer, 256)
-      wallet = Wallet.fromPrivateKey(appKeyPrivKey)
-    }
-
-    return wallet
-  }
-
-  getPrivateKeyFor (address, opts = {}) {
-    if (!address) {
-      throw new Error('Must specify address.');
-    }
-    const wallet = this._getWalletForAccount(address, opts)
-    const privKey = ethUtil.toBuffer(wallet.getPrivateKey())
-    return privKey;
-  }
-
 }
 
 HdKeyring.type = type

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-hd-keyring",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "A simple standard interface for a seed phrase generated set of Ethereum accounts.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This class was overwriting some methods that were more correctly implemented in the `eth-simpele-keyring` class that was being inherited from.

Fixes https://github.com/MetaMask/metamask-snaps-beta/issues/122