### PR TITLE
Remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,6 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-0.2.4.tgz",
       "integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
     },
-    "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true,
-      "requires": {
-        "util": "0.10.3"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -33,11 +24,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-    },
-    "bignumber.js": {
-      "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-      "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-      "dev": true
     },
     "bindings": {
       "version": "1.3.0",
@@ -207,12 +193,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "crypto-js": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
-      "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU=",
-      "dev": true
-    },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
@@ -285,9 +265,9 @@
       },
       "dependencies": {
         "eth-sig-util": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.0.tgz",
-          "integrity": "sha512-ahApxr+e1cls/GwcFSGsgRLrMqG6D6cBnK9CRHhx97O/s9ow+URIxbPvov8jfE70ZnNBdHMircoSCpi1b4QHjA==",
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.1.tgz",
+          "integrity": "sha512-F5k+6gdSphUtHwCsj0QD59gwxxXoG+ZiFODgTiGS7xc53tPcjBSdBRuhcXdLwXGiytsjk+77oYQRRYeAKXIjBQ==",
           "requires": {
             "buffer": "^5.2.1",
             "elliptic": "^6.4.0",
@@ -386,12 +366,6 @@
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
       }
-    },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -823,40 +797,10 @@
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
       "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
     },
-    "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
-      }
-    },
     "uuid": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-    },
-    "web3": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
-      "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
-      "dev": true,
-      "requires": {
-        "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-        "crypto-js": "^3.1.4",
-        "utf8": "^2.1.1",
-        "xhr2": "*",
-        "xmlhttprequest": "*"
-      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -864,22 +808,10 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "xhr2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
-      "dev": true
-    },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-      "dev": true
-    },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,16 +24,11 @@
     "bip39": "^2.2.0",
     "eth-sig-util": "^2.4.4",
     "eth-simple-keyring": "^3.4.0",
-    "ethereumjs-abi": "^0.6.5",
     "ethereumjs-util": "^5.1.1",
     "ethereumjs-wallet": "^0.6.0",
-    "events": "^1.1.1",
-    "xtend": "^4.0.1"
+    "events": "^1.1.1"
   },
   "devDependencies": {
-    "assert": "^1.4.1",
-    "extend": "^3.0.0",
-    "mocha": "^3.2.0",
-    "web3": "^0.18.2"
+    "mocha": "^3.2.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,4 @@
 const assert = require('assert')
-const extend = require('xtend')
 const HdKeyring = require('../')
 const sigUtil = require('eth-sig-util')
 const ethUtil = require('ethereumjs-util')


### PR DESCRIPTION
The dependency `xtend` was used one time to populate an unused variable, and `ethereumjs-abi`, `extend`, and `web3` weren't used at all. `assert` was used within the tests, but the Node.js built-in `assert` module was sufficient there.