### PR TITLE
Replace `withAppKeyOrigin` option with `getAppKey`

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ class HdKeyring extends SimpleKeyring {
   }
 
 
-  _getWalletForAccount (account, opts = {}) {
+  _getWalletForAccount (account) {
     const targetAddress = sigUtil.normalize(account)
 
     let wallet = this.wallets.find((w) => {
@@ -94,22 +94,14 @@ class HdKeyring extends SimpleKeyring {
               (sigUtil.normalize(address) === targetAddress))
     })
 
-    if (opts.withAppKeyOrigin) {
-      const privKey = wallet.getPrivateKey()
-      const appKeyOriginBuffer = Buffer.from(opts.withAppKeyOrigin, 'utf8')
-      const appKeyBuffer = Buffer.concat([privKey, appKeyOriginBuffer])
-      const appKeyPrivKey = ethUtil.keccak(appKeyBuffer, 256)
-      wallet = Wallet.fromPrivateKey(appKeyPrivKey)
-    }
-
     return wallet
   }
 
-  getPrivateKeyFor (address, opts = {}) {
+  getPrivateKeyFor (address) {
     if (!address) {
       throw new Error('Must specify address.');
     }
-    const wallet = this._getWalletForAccount(address, opts)
+    const wallet = this._getWalletForAccount(address)
     const privKey = ethUtil.toBuffer(wallet.getPrivateKey())
     return privKey;
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "bip39": "^2.2.0",
     "eth-sig-util": "^2.4.4",
-    "eth-simple-keyring": "^3.4.0",
+    "eth-simple-keyring": "^4.0.0",
     "ethereumjs-abi": "^0.6.5",
     "ethereumjs-util": "^5.1.1",
     "ethereumjs-wallet": "^0.6.0",


### PR DESCRIPTION
The new `getAppKey` method will return the private app key derived from the provided origin. This serves as an alternative to optionally augmenting each keyring method with a set of options that may contain a `withAppKeyOrigin` value.

Moving app key generation to a single place makes it easier to limit access to sensitive information, such as the primary private keys. It also allows the consumer to use app keys more efficiently by using the same wallet for successive operations, rather than generating a new private key each time with `keccak`.

The private app key returned can itself be used to instantiate a new keyring instance, which allows app keys to perform all the same functions that a 'normal' key would allow.