### PR TITLE
Rename the package to be under the `@metamask` scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A simple JS class wrapped around [ethereumjs-wallet](https://github.com/ethereumjs/ethereumjs-wallet) designed to expose an interface common to many different signing strategies, to be used in a `KeyringController`, like is being used in [MetaMask](https://metamask.io/)
 
+## Installation
+
+`yarn add @metamask/eth-hd-keyring`
+
+or
+
+`npm install @metamask/eth-hd-keyring`
+
 ## The Keyring Class Protocol
 
 One of the goals of this class is to allow developers to easily add new signing strategies to MetaMask. We call these signing strategies Keyrings, because they can manage multiple keys.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eth-hd-keyring",
+  "name": "@metamask/eth-hd-keyring",
   "version": "3.6.0",
   "description": "A simple standard interface for a seed phrase generated set of Ethereum accounts.",
   "engines": {
@@ -39,5 +39,9 @@
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-node": "^11.1.0",
     "mocha": "^8.1.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
The package is now called `@metamask/eth-hd-keyring` rather than `eth-hd-keyring`.

The manifest has been updated with the `publishConfig` property, as it is required for publishing scoped packages. An installation section has been added to the README as well.