### PR TITLE
feat:upgrade bip39

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,8 @@ class HdKeyring extends SimpleKeyring {
 
   _initFromMnemonic(mnemonic) {
     this.mnemonic = mnemonic;
-    const seed = bip39.mnemonicToSeed(mnemonic);
+    // eslint-disable-next-line node/no-sync
+    const seed = bip39.mnemonicToSeedSync(mnemonic);
     this.hdWallet = hdkey.fromMasterSeed(seed);
     this.root = this.hdWallet.derivePath(this.hdPath);
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@metamask/eth-sig-util": "^4.0.0",
-    "bip39": "^2.2.0",
+    "bip39": "^3.0.4",
     "eth-simple-keyring": "^4.2.0",
     "ethereumjs-util": "^7.0.9",
     "ethereumjs-wallet": "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,6 +191,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.36.tgz#5637905dbb15c30a33a3c65b9ef7c20e3c85ebad"
   integrity sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ==
 
+"@types/node@11.11.6":
+  version "11.11.6"
+  resolved "https://registry.npmmirror.com/@types/node/download/@types/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
+  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
+
 "@types/pbkdf2@^3.0.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@types/pbkdf2/-/pbkdf2-3.1.0.tgz#039a0e9b67da0cdc4ee5dab865caa6b267bb66b1"
@@ -436,16 +441,15 @@ bindings@^1.2.1:
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
   integrity sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==
 
-bip39@^2.2.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.5.0.tgz#51cbd5179460504a63ea3c000db3f787ca051235"
-  integrity sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==
+bip39@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.nlark.com/bip39/download/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
+  integrity sha1-WxH+2WaEC14bhTnw9Uq2OSlpsqA=
   dependencies:
+    "@types/node" "11.11.6"
     create-hash "^1.1.0"
     pbkdf2 "^3.0.9"
     randombytes "^2.0.1"
-    safe-buffer "^5.0.1"
-    unorm "^1.3.3"
 
 bip66@^1.1.3:
   version "1.1.5"
@@ -3245,11 +3249,6 @@ unbox-primitive@^1.0.1:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
-
-unorm@^1.3.3:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.4.1.tgz#364200d5f13646ca8bcd44490271335614792300"
-  integrity sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA=
 
 uri-js@^4.2.2:
   version "4.4.0"


### PR DESCRIPTION
KeyringController is relying on the latest version of bip39.
Staying the line with KeyringController will somehow reduce the bundle size.

2.x version of bip39 has been out for 4 years.
The latest version, 3.0.4, of bip39 has been out for 8 months.

[KeyringController`s dependency](https://github.com/MetaMask/KeyringController/blob/main/package.json#L34)
[Changelog of bip39](https://github.com/bitcoinjs/bip39/blob/master/CHANGELOG.md)
[Versions of bip39](https://www.npmjs.com/package/bip39)
