### PR TITLE
do not allow re-initialization of keyring instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ class HdKeyring extends SimpleKeyring {
     this.deserialize(opts);
   }
 
+  generateRandomMnemonic() {
+    this._initFromMnemonic(bip39.generateMnemonic());
+  }
+
   serialize() {
     return Promise.resolve({
       mnemonic: this.mnemonic,
@@ -43,7 +47,7 @@ class HdKeyring extends SimpleKeyring {
 
   addAccounts(numberOfAccounts = 1) {
     if (!this.root) {
-      this._initFromMnemonic(bip39.generateMnemonic());
+      throw new Error('Eth-Hd-Keyring: No secret recovery phrase provided');
     }
 
     const oldLen = this.wallets.length;
@@ -71,6 +75,11 @@ class HdKeyring extends SimpleKeyring {
   /* PRIVATE METHODS */
 
   _initFromMnemonic(mnemonic) {
+    if (this.root) {
+      throw new Error(
+        'Eth-Hd-Keyring: Secret recovery phrase already provided',
+      );
+    }
     this.mnemonic = mnemonic;
     // eslint-disable-next-line node/no-sync
     const seed = bip39.mnemonicToSeedSync(mnemonic);

--- a/index.js
+++ b/index.js
@@ -28,6 +28,12 @@ class HdKeyring extends SimpleKeyring {
   }
 
   deserialize(opts = {}) {
+    if (this.root) {
+      throw new Error(
+        'Eth-Hd-Keyring: Secret recovery phrase already provided',
+      );
+    }
+
     this.opts = opts || {};
     this.wallets = [];
     this.mnemonic = null;

--- a/index.js
+++ b/index.js
@@ -86,6 +86,13 @@ class HdKeyring extends SimpleKeyring {
         'Eth-Hd-Keyring: Secret recovery phrase already provided',
       );
     }
+    // validate before initializing
+    const isValid = bip39.validateMnemonic(mnemonic);
+    if (!isValid) {
+      throw new Error(
+        'Eth-Hd-Keyring: Invalid secret recovery phrase provided',
+      );
+    }
     this.mnemonic = mnemonic;
     // eslint-disable-next-line node/no-sync
     const seed = bip39.mnemonicToSeedSync(mnemonic);

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,53 @@ describe('hd-keyring', function () {
     });
   });
 
+  describe('re-initialization protection', function () {
+    it('double generateRandomMnemonic', function (done) {
+      keyring.generateRandomMnemonic();
+      let error;
+      try {
+        keyring.generateRandomMnemonic();
+      } catch (err) {
+        error = err;
+      }
+      assert.ok(error);
+      done();
+    });
+
+    it('constructor + generateRandomMnemonic', function (done) {
+      keyring = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        numberOfAccounts: 2,
+      });
+      let error;
+      try {
+        keyring.generateRandomMnemonic();
+      } catch (err) {
+        error = err;
+      }
+      assert.ok(error);
+      done();
+    });
+
+    it('constructor + deserialize', function (done) {
+      keyring = new HdKeyring({
+        mnemonic: sampleMnemonic,
+        numberOfAccounts: 2,
+      });
+      let error;
+      try {
+        keyring.deserialize({
+          mnemonic: sampleMnemonic,
+          numberOfAccounts: 1,
+        });
+      } catch (err) {
+        error = err;
+      }
+      assert.ok(error);
+      done();
+    });
+  });
+
   describe('Keyring.type', function () {
     it('is a class property that returns the type string.', function () {
       const { type } = HdKeyring;

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,20 @@ describe('hd-keyring', function () {
         done();
       });
     });
+
+    it('throws on invalid mnemonic', function (done) {
+      let error;
+      try {
+        keyring = new HdKeyring({
+          mnemonic: 'abc xyz',
+          numberOfAccounts: 2,
+        });
+      } catch (err) {
+        error = err;
+      }
+      assert.ok(error);
+      done();
+    });
   });
 
   describe('re-initialization protection', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -95,6 +95,7 @@ describe('hd-keyring', function () {
   describe('#addAccounts', function () {
     describe('with no arguments', function () {
       it('creates a single wallet', function (done) {
+        keyring.generateRandomMnemonic();
         keyring.addAccounts().then(() => {
           assert.equal(keyring.wallets.length, 1);
           done();
@@ -104,6 +105,7 @@ describe('hd-keyring', function () {
 
     describe('with a numeric argument', function () {
       it('creates that number of wallets', function (done) {
+        keyring.generateRandomMnemonic();
         keyring.addAccounts(3).then(() => {
           assert.equal(keyring.wallets.length, 3);
           done();
@@ -175,6 +177,7 @@ describe('hd-keyring', function () {
           value: 'Hi, Alice!',
         },
       ];
+      keyring.generateRandomMnemonic();
       await keyring.addAccounts(1);
       const addresses = await keyring.getAccounts();
       const address = addresses[0];
@@ -198,6 +201,7 @@ describe('hd-keyring', function () {
     ];
 
     it('signs in a compliant and recoverable way', async function () {
+      keyring.generateRandomMnemonic();
       await keyring.addAccounts(1);
       const addresses = await keyring.getAccounts();
       const address = addresses[0];
@@ -278,6 +282,7 @@ describe('hd-keyring', function () {
         },
       };
 
+      keyring.generateRandomMnemonic();
       await keyring.addAccounts(1);
       const addresses = await keyring.getAccounts();
       const address = addresses[0];


### PR DESCRIPTION
Based on `LeastAuthority Audit December 2021`: `Suggestion 1` and `Suggestion 5`

this would be a breaking change in behavior (requires consumer to call `generateRandomMnemonic()` after initialization for creating new SRPs)
