### PR TITLE
patch serialize and _initFromMnemonic to account for instances where mnemonic could be buffer array or string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { hdkey } = require('ethereumjs-wallet');
 const SimpleKeyring = require('eth-simple-keyring');
-const bip39 = require('bip39');
+const bip39 = require('@metamask/bip39');
 const { normalize } = require('@metamask/eth-sig-util');
 
 // Options:
@@ -90,7 +90,8 @@ class HdKeyring extends SimpleKeyring {
    * BIP39-compliant mnemonic.
    *
    * @param {string|Array<number>|Buffer} mnemonic - A seed phrase represented
-   * as a string, an array of UTF-8 bytes, or a Buffer.
+   * as a string, an array of UTF-8 bytes, or a Buffer. All mnemonic input params
+   * regardless of type should be NFKD normalized.
    */
   _initFromMnemonic(mnemonic) {
     if (this.root) {

--- a/index.js
+++ b/index.js
@@ -90,8 +90,8 @@ class HdKeyring extends SimpleKeyring {
    * BIP39-compliant mnemonic.
    *
    * @param {string|Array<number>|Buffer} mnemonic - A seed phrase represented
-   * as a string, an array of UTF-8 bytes, or a Buffer. All mnemonic input params
-   * regardless of type should be NFKD normalized.
+   * as a string, an array of UTF-8 bytes, or a Buffer. Mnemonic input
+   * passed as type buffer or array of UTF-8 bytes must be NFKD normalized.
    */
   _initFromMnemonic(mnemonic) {
     if (this.root) {

--- a/index.js
+++ b/index.js
@@ -20,8 +20,13 @@ class HdKeyring extends SimpleKeyring {
   }
 
   serialize() {
+    const mnemonicAsBuffer =
+      typeof this.mnemonic === 'string'
+        ? Buffer.from(this.mnemonic, 'utf8')
+        : this.mnemonic;
+
     return Promise.resolve({
-      mnemonic: this.mnemonic,
+      mnemonic: Array.from(mnemonicAsBuffer.values()),
       numberOfAccounts: this.wallets.length,
       hdPath: this.hdPath,
     });
@@ -80,6 +85,13 @@ class HdKeyring extends SimpleKeyring {
 
   /* PRIVATE METHODS */
 
+  /**
+   * Sets appropriate properties for the keyring based on the given
+   * BIP39-compliant mnemonic.
+   *
+   * @param {string|Array<number>|Buffer} mnemonic - A seed phrase represented
+   * as a string, an array of UTF-8 bytes, or a Buffer.
+   */
   _initFromMnemonic(mnemonic) {
     if (this.root) {
       throw new Error(
@@ -93,7 +105,15 @@ class HdKeyring extends SimpleKeyring {
         'Eth-Hd-Keyring: Invalid secret recovery phrase provided',
       );
     }
-    this.mnemonic = mnemonic;
+
+    if (typeof mnemonic === 'string') {
+      this.mnemonic = Buffer.from(mnemonic, 'utf8');
+    } else if (Array.isArray(mnemonic)) {
+      this.mnemonic = Buffer.from(mnemonic);
+    } else {
+      this.mnemonic = mnemonic;
+    }
+
     // eslint-disable-next-line node/no-sync
     const seed = bip39.mnemonicToSeedSync(mnemonic);
     this.hdWallet = hdkey.fromMasterSeed(seed);

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "test": "mocha"
   },
   "dependencies": {
+    "@metamask/bip39": "^4.0.0",
     "@metamask/eth-sig-util": "^4.0.0",
-    "bip39": "^3.0.4",
     "eth-simple-keyring": "^4.2.0",
     "ethereumjs-util": "^7.0.9",
     "ethereumjs-wallet": "^1.0.1"

--- a/test/index.js
+++ b/test/index.js
@@ -117,12 +117,11 @@ describe('hd-keyring', function () {
   });
 
   describe('#serialize mnemonic.', function () {
-    it('serializes mnemonic into a bufferArray', function () {
-      keyring.generateRandomMnemonic()
+    it('serializes mnemonic class variable into a buffer array and does not add accounts', function () {
+      keyring.generateRandomMnemonic();
       keyring.serialize().then((output) => {
         assert.equal(output.numberOfAccounts, 0);
-        assert.equal(typeof output.mnemonic, 'array');
-        assert.equal(output.mnemonic.length, 85);
+        assert.equal(Array.isArray(output.mnemonic), true);
       });
     });
   });
@@ -145,11 +144,13 @@ describe('hd-keyring', function () {
           assert.equal(accounts[0], firstAcct);
           assert.equal(accounts[1], secondAcct);
           assert.equal(accounts.length, 2);
-
           return keyring.serialize();
         })
         .then((serialized) => {
-          assert.equal(serialized.mnemonic, sampleMnemonic);
+          assert.equal(
+            Buffer.from(serialized.mnemonic).toString(),
+            sampleMnemonic,
+          );
           done();
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -116,11 +116,13 @@ describe('hd-keyring', function () {
     });
   });
 
-  describe('#serialize empty wallets.', function () {
-    it('serializes a new mnemonic', function () {
+  describe('#serialize mnemonic.', function () {
+    it('serializes mnemonic into a bufferArray', function () {
+      keyring.generateRandomMnemonic()
       keyring.serialize().then((output) => {
         assert.equal(output.numberOfAccounts, 0);
-        assert.equal(output.mnemonic, null);
+        assert.equal(typeof output.mnemonic, 'array');
+        assert.equal(output.mnemonic.length, 85);
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,6 +80,16 @@
     semver "^7.3.5"
     yargs "^17.0.1"
 
+"@metamask/bip39@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/bip39/-/bip39-4.0.0.tgz#1cb867a8454e3d45d065107b4e070d58bdb64aac"
+  integrity sha512-xH2g8mFe9p2WePnKeQJH4U8MB6pWPyvwpsz4stb0YdnMOR7cKA6Jm/KOSFiPKr1i9+AzNDImt/XxhwF5ej4jXQ==
+  dependencies:
+    "@types/node" "11.11.6"
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
+
 "@metamask/eslint-config-mocha@^8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config-mocha/-/eslint-config-mocha-8.0.0.tgz#522287c45bec87cb6ab051fa47cdfa7f3000c7cf"
@@ -440,16 +450,6 @@ bindings@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
   integrity sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==
-
-bip39@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.nlark.com/bip39/download/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
-  integrity sha1-WxH+2WaEC14bhTnw9Uq2OSlpsqA=
-  dependencies:
-    "@types/node" "11.11.6"
-    create-hash "^1.1.0"
-    pbkdf2 "^3.0.9"
-    randombytes "^2.0.1"
 
 bip66@^1.1.3:
   version "1.1.5"


### PR DESCRIPTION
Adds patch of this package [currently implemented extension side](https://github.com/MetaMask/metamask-extension/blob/develop/patches/eth-hd-keyring%2B3.6.0.patch) to this repo.