### PR TITLE
fix _initFromMnemonic bug + get test coverage to 100%

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,7 @@ class HdKeyring extends SimpleKeyring {
         'Eth-Hd-Keyring: Secret recovery phrase already provided',
       );
     }
-
-    this.opts = opts || {};
+    this.opts = opts;
     this.wallets = [];
     this.mnemonic = null;
     this.root = null;
@@ -116,7 +115,7 @@ class HdKeyring extends SimpleKeyring {
     }
 
     // eslint-disable-next-line node/no-sync
-    const seed = bip39.mnemonicToSeedSync(mnemonic);
+    const seed = bip39.mnemonicToSeedSync(this.mnemonic);
     this.hdWallet = hdkey.fromMasterSeed(seed);
     this.root = this.hdWallet.derivePath(this.hdPath);
   }

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,13 @@ const privKeyHex =
 
 const sampleMnemonic =
   'finish oppose decorate face calm tragic certain desk hour urge dinosaur mango';
+const sampleBufferArrayMnemonic = [
+  102, 105, 110, 105, 115, 104, 32, 111, 112, 112, 111, 115, 101, 32, 100, 101,
+  99, 111, 114, 97, 116, 101, 32, 102, 97, 99, 101, 32, 99, 97, 108, 109, 32,
+  116, 114, 97, 103, 105, 99, 32, 99, 101, 114, 116, 97, 105, 110, 32, 100, 101,
+  115, 107, 32, 104, 111, 117, 114, 32, 117, 114, 103, 101, 32, 100, 105, 110,
+  111, 115, 97, 117, 114, 32, 109, 97, 110, 103, 111,
+];
 const firstAcct = '0x1c96099350f13d558464ec79b9be4445aa0ef579';
 const secondAcct = '0x1b00aed43a693f3a957f9feb5cc08afa031e37a0';
 
@@ -25,9 +32,20 @@ describe('hd-keyring', () => {
   });
 
   describe('constructor', () => {
-    it('constructs', async () => {
+    it('constructs with a typeof string mnemonic', async () => {
       keyring = new HdKeyring({
         mnemonic: sampleMnemonic,
+        numberOfAccounts: 2,
+      });
+
+      const accounts = await keyring.getAccounts();
+      expect(accounts[0]).toStrictEqual(firstAcct);
+      expect(accounts[1]).toStrictEqual(secondAcct);
+    });
+
+    it('constructs with a typeof array mnemonic', async () => {
+      keyring = new HdKeyring({
+        mnemonic: sampleBufferArrayMnemonic,
         numberOfAccounts: 2,
       });
 
@@ -99,8 +117,15 @@ describe('hd-keyring', () => {
   });
 
   describe('#serialize mnemonic.', () => {
-    it('serializes mnemonic class variable into a buffer array and does not add accounts', async () => {
+    it('serializes mnemonic stored as a buffer in a class variable into a buffer array and does not add accounts', async () => {
       keyring.generateRandomMnemonic();
+      const output = await keyring.serialize();
+      expect(output.numberOfAccounts).toBe(0);
+      expect(Array.isArray(output.mnemonic)).toBe(true);
+    });
+
+    it('serializes mnemonic stored as a string in a class variable into a buffer array and does not add accounts', async () => {
+      keyring.mnemonic = sampleMnemonic;
       const output = await keyring.serialize();
       expect(output.numberOfAccounts).toBe(0);
       expect(Array.isArray(output.mnemonic)).toBe(true);
@@ -132,6 +157,12 @@ describe('hd-keyring', () => {
         keyring.generateRandomMnemonic();
         await keyring.addAccounts();
         expect(keyring.wallets).toHaveLength(1);
+      });
+
+      it('throws an error when no SRP has been generated yet', async () => {
+        expect(() => keyring.addAccounts()).toThrow(
+          'Eth-Hd-Keyring: No secret recovery phrase provided',
+        );
       });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -15,13 +15,6 @@ const privKeyHex =
 
 const sampleMnemonic =
   'finish oppose decorate face calm tragic certain desk hour urge dinosaur mango';
-const sampleBufferArrayMnemonic = [
-  102, 105, 110, 105, 115, 104, 32, 111, 112, 112, 111, 115, 101, 32, 100, 101,
-  99, 111, 114, 97, 116, 101, 32, 102, 97, 99, 101, 32, 99, 97, 108, 109, 32,
-  116, 114, 97, 103, 105, 99, 32, 99, 101, 114, 116, 97, 105, 110, 32, 100, 101,
-  115, 107, 32, 104, 111, 117, 114, 32, 117, 114, 103, 101, 32, 100, 105, 110,
-  111, 115, 97, 117, 114, 32, 109, 97, 110, 103, 111,
-];
 const firstAcct = '0x1c96099350f13d558464ec79b9be4445aa0ef579';
 const secondAcct = '0x1b00aed43a693f3a957f9feb5cc08afa031e37a0';
 
@@ -45,7 +38,18 @@ describe('hd-keyring', () => {
 
     it('constructs with a typeof array mnemonic', async () => {
       keyring = new HdKeyring({
-        mnemonic: sampleBufferArrayMnemonic,
+        mnemonic: Array.from(Buffer.from(sampleMnemonic, 'utf8').values()),
+        numberOfAccounts: 2,
+      });
+
+      const accounts = await keyring.getAccounts();
+      expect(accounts[0]).toStrictEqual(firstAcct);
+      expect(accounts[1]).toStrictEqual(secondAcct);
+    });
+
+    it('constructs with a typeof buffer mnemonic', async () => {
+      keyring = new HdKeyring({
+        mnemonic: Buffer.from(sampleMnemonic, 'utf8'),
         numberOfAccounts: 2,
       });
 


### PR DESCRIPTION
- Fix bug where we are passing the unbuffered mnemonic to `bip39.mnemonicToSeedSync` when `_initFromMnemonic` is passed a typeof string mnemonic 

- Bump unit test coverage to 100%