### PR TITLE
add arg validation for method deserialize

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,12 @@ class HdKeyring extends SimpleKeyring {
   }
 
   deserialize(opts = {}) {
+    if (opts.numberOfAccounts && !opts.mnemonic) {
+      throw new Error(
+        'Eth-Hd-Keyring: Deserialize method cannot be called with an opts value for numberOfAccounts and no menmonic',
+      );
+    }
+
     if (this.root) {
       throw new Error(
         'Eth-Hd-Keyring: Secret recovery phrase already provided',

--- a/test/index.js
+++ b/test/index.js
@@ -67,6 +67,17 @@ describe('hd-keyring', () => {
           }),
       ).toThrow('Eth-Hd-Keyring: Invalid secret recovery phrase provided');
     });
+
+    it('throws when numberOfAccounts is passed with no mnemonic', () => {
+      expect(
+        () =>
+          new HdKeyring({
+            numberOfAccounts: 2,
+          }),
+      ).toThrow(
+        'Eth-Hd-Keyring: Deserialize method cannot be called with an opts value for numberOfAccounts and no menmonic',
+      );
+    });
   });
 
   describe('re-initialization protection', () => {


### PR DESCRIPTION
The method `deserialize` cannot be called with an arg for `numberOfAccounts` without a corresponding `mnemonic`. Because this was not the case prior to major release 4.0.0 we should provide consumers with an error indicating how to adapt.