### PR TITLE
bump eth-simple-keyring version to v5

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const { hdkey } = require('ethereumjs-wallet');
-const SimpleKeyring = require('eth-simple-keyring');
+const SimpleKeyring = require('@metamask/eth-simple-keyring');
 const bip39 = require('@metamask/scure-bip39');
 const { wordlist } = require('@metamask/scure-bip39/dist/wordlists/english');
 const { normalize } = require('@metamask/eth-sig-util');
@@ -65,7 +65,7 @@ class HdKeyring extends SimpleKeyring {
   serialize() {
     return Promise.resolve({
       mnemonic: this.mnemonicToUint8Array(this.mnemonic),
-      numberOfAccounts: this.wallets.length,
+      numberOfAccounts: this._wallets.length,
       hdPath: this.hdPath,
     });
   }
@@ -83,7 +83,7 @@ class HdKeyring extends SimpleKeyring {
       );
     }
     this.opts = opts;
-    this.wallets = [];
+    this._wallets = [];
     this.mnemonic = null;
     this.root = null;
     this.hdPath = opts.hdPath || hdPathString;
@@ -104,13 +104,13 @@ class HdKeyring extends SimpleKeyring {
       throw new Error('Eth-Hd-Keyring: No secret recovery phrase provided');
     }
 
-    const oldLen = this.wallets.length;
+    const oldLen = this._wallets.length;
     const newWallets = [];
     for (let i = oldLen; i < numberOfAccounts + oldLen; i++) {
       const child = this.root.deriveChild(i);
       const wallet = child.getWallet();
       newWallets.push(wallet);
-      this.wallets.push(wallet);
+      this._wallets.push(wallet);
     }
     const hexWallets = newWallets.map((w) => {
       return normalize(w.getAddress().toString('hex'));
@@ -120,7 +120,7 @@ class HdKeyring extends SimpleKeyring {
 
   getAccounts() {
     return Promise.resolve(
-      this.wallets.map((w) => {
+      this._wallets.map((w) => {
         return normalize(w.getAddress().toString('hex'));
       }),
     );

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@metamask/eth-sig-util": "^4.0.0",
+    "@metamask/eth-simple-keyring": "^5.0.0",
     "@metamask/scure-bip39": "^2.0.3",
-    "eth-simple-keyring": "^4.2.0",
     "ethereumjs-wallet": "^1.0.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -200,7 +200,7 @@ describe('hd-keyring', () => {
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1,
       });
-      expect(keyring.wallets).toHaveLength(1);
+      expect(keyring._wallets).toHaveLength(1);
       await keyring.addAccounts(1);
       const accounts = await keyring.getAccounts();
       expect(accounts[0]).toStrictEqual(firstAcct);
@@ -218,7 +218,7 @@ describe('hd-keyring', () => {
       it('creates a single wallet', async () => {
         keyring.generateRandomMnemonic();
         await keyring.addAccounts();
-        expect(keyring.wallets).toHaveLength(1);
+        expect(keyring._wallets).toHaveLength(1);
       });
 
       it('throws an error when no SRP has been generated yet', async () => {
@@ -232,7 +232,7 @@ describe('hd-keyring', () => {
       it('creates that number of wallets', async () => {
         keyring.generateRandomMnemonic();
         await keyring.addAccounts(3);
-        expect(keyring.wallets).toHaveLength(3);
+        expect(keyring._wallets).toHaveLength(3);
       });
     });
   });
@@ -241,7 +241,7 @@ describe('hd-keyring', () => {
     it('calls getAddress on each wallet', async () => {
       // Push a mock wallet
       const desiredOutput = 'foo';
-      keyring.wallets.push({
+      keyring._wallets.push({
         getAddress() {
           return {
             toString() {
@@ -317,7 +317,7 @@ describe('hd-keyring', () => {
       await keyring.addAccounts(1);
       const addresses = await keyring.getAccounts();
       const address = addresses[0];
-      const signature = await keyring.signTypedData_v1(address, typedData);
+      const signature = await keyring.signTypedData(address, typedData);
       const restored = recoverTypedSignature({
         data: typedData,
         signature,
@@ -344,7 +344,9 @@ describe('hd-keyring', () => {
       });
       const addresses = await keyring.getAccounts();
       const address = addresses[0];
-      const signature = await keyring.signTypedData_v3(address, typedData);
+      const signature = await keyring.signTypedData(address, typedData, {
+        version: SignTypedDataVersion.V3,
+      });
       const restored = recoverTypedSignature({
         data: typedData,
         signature,
@@ -398,7 +400,9 @@ describe('hd-keyring', () => {
       await keyring.addAccounts(1);
       const addresses = await keyring.getAccounts();
       const address = addresses[0];
-      const signature = await keyring.signTypedData_v3(address, typedData);
+      const signature = await keyring.signTypedData(address, typedData, {
+        version: SignTypedDataVersion.V3,
+      });
       const restored = recoverTypedSignature({
         data: typedData,
         signature,
@@ -589,8 +593,9 @@ describe('hd-keyring', () => {
         numberOfAccounts: 1,
       });
 
-      const sig = await keyring.signTypedData_v3(address, typedData, {
+      const sig = await keyring.signTypedData(address, typedData, {
         withAppKeyOrigin: 'someapp.origin.io',
+        version: SignTypedDataVersion.V3,
       });
       expect(sig).toStrictEqual(expectedSig);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,6 +317,15 @@
   resolved "https://registry.yarnpkg.com/@ethereumjs/rlp/-/rlp-4.0.0-beta.3.tgz#61ad6a535c03e0281f8ddf72a3dbd64b2a3d78da"
   integrity sha512-pvQqtxPJCn2vxm8AJtKUv7+IOqgOb5gf+4xhO5qcRDXzk6Ef/RX+g1xzA3Dss/wd/jV4nPN1jUGHjsIzhtp4EQ==
 
+"@ethereumjs/util@^8.0.0":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/util/-/util-8.0.2.tgz#b7348fc7253649b0f00685a94546c6eee1fad819"
+  integrity sha512-b1Fcxmq+ckCdoLPhVIBkTcH8szigMapPuEmD8EDakvtI5Na5rzmX1sBW73YQqaPc7iUxGCAzZP1LrFQ7aEMugA==
+  dependencies:
+    "@ethereumjs/rlp" "^4.0.0-beta.2"
+    async "^3.2.4"
+    ethereum-cryptography "^1.1.2"
+
 "@ethereumjs/util@^8.0.0-beta.3":
   version "8.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/@ethereumjs/util/-/util-8.0.0-beta.3.tgz#1ace6d4effc0e8a0345656e1bafe3845caf5d653"
@@ -638,6 +647,28 @@
     ethjs-util "^0.1.6"
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
+
+"@metamask/eth-sig-util@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-5.0.2.tgz#c518279a6e17a88135a13d53a0b970f145ff8bce"
+  integrity sha512-RU6fG/H6/UlBol221uBkq5C7w3TwLK611nEZliO2u+kO0vHKGBXnIPlhI0tzKUigjhUeOd9mhCNbNvhh0LKt9Q==
+  dependencies:
+    "@ethereumjs/util" "^8.0.0"
+    bn.js "^4.11.8"
+    ethereum-cryptography "^1.1.2"
+    ethjs-util "^0.1.6"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
+
+"@metamask/eth-simple-keyring@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-simple-keyring/-/eth-simple-keyring-5.0.0.tgz#307772d1aa3298e41a2444b428cd8f4522b7bf5c"
+  integrity sha512-UJfP36Z9g1eeD8mSHWaVqUvkgbgYm3S7YuzlMzQi+WgPnWu81CdbldMMtvreTlu4I1mTyljXLDMjIp65P0bygQ==
+  dependencies:
+    "@ethereumjs/util" "^8.0.0"
+    "@metamask/eth-sig-util" "^5.0.1"
+    ethereum-cryptography "^1.1.2"
+    randombytes "^2.1.0"
 
 "@metamask/scure-bip39@^2.0.3":
   version "2.0.3"
@@ -1123,6 +1154,11 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
+async@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 asynckit@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Bumps `eth-simple-keyring`  to (newly named) `@metamask/eth-simple-keyring` version 5.0.0 (latest) and adapts accordingly:
 - class property `wallets` becomes `_wallets` (still accessing it even tho it's marked private,  because we're going to remove this inheritance pattern immediately after)
 - `signTypedData_v<1,3,4>`  becomes `signTypedData` and received a version arg in options.