### PR TITLE
Make new internal methods private

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,19 +37,19 @@ class HdKeyring {
     this._initFromMnemonic(bip39.generateMnemonic(wordlist));
   }
 
-  uint8ArrayToString(mnemonic) {
+  _uint8ArrayToString(mnemonic) {
     const recoveredIndices = Array.from(
       new Uint16Array(new Uint8Array(mnemonic).buffer),
     );
     return recoveredIndices.map((i) => wordlist[i]).join(' ');
   }
 
-  stringToUint8Array(mnemonic) {
+  _stringToUint8Array(mnemonic) {
     const indices = mnemonic.split(' ').map((word) => wordlist.indexOf(word));
     return new Uint8Array(new Uint16Array(indices).buffer);
   }
 
-  mnemonicToUint8Array(mnemonic) {
+  _mnemonicToUint8Array(mnemonic) {
     let mnemonicData = mnemonic;
     // when encrypted/decrypted, buffers get cast into js object with a property type set to buffer
     if (mnemonic && mnemonic.type && mnemonic.type === 'Buffer') {
@@ -68,7 +68,7 @@ class HdKeyring {
       } else if (Buffer.isBuffer(mnemonicData)) {
         mnemonicAsString = mnemonicData.toString();
       }
-      return this.stringToUint8Array(mnemonicAsString);
+      return this._stringToUint8Array(mnemonicAsString);
     } else if (
       mnemonicData instanceof Object &&
       !(mnemonicData instanceof Uint8Array)
@@ -81,7 +81,7 @@ class HdKeyring {
 
   serialize() {
     return Promise.resolve({
-      mnemonic: this.mnemonicToUint8Array(this.mnemonic),
+      mnemonic: this._mnemonicToUint8Array(this.mnemonic),
       numberOfAccounts: this._wallets.length,
       hdPath: this.hdPath,
     });
@@ -278,7 +278,7 @@ class HdKeyring {
       );
     }
 
-    this.mnemonic = this.mnemonicToUint8Array(mnemonic);
+    this.mnemonic = this._mnemonicToUint8Array(mnemonic);
 
     // validate before initializing
     const isValid = bip39.validateMnemonic(this.mnemonic, wordlist);

--- a/test/index.js
+++ b/test/index.js
@@ -184,7 +184,7 @@ describe('hd-keyring', () => {
   describe('#serialize mnemonic.', () => {
     it('serializes mnemonic stored as a buffer to a Uint8Array', async () => {
       keyring.mnemonic = oldMMForkBIP39.generateMnemonic();
-      const mnemonicAsUint8Array = keyring.stringToUint8Array(
+      const mnemonicAsUint8Array = keyring._stringToUint8Array(
         keyring.mnemonic.toString(),
       );
       const output = await keyring.serialize();
@@ -208,7 +208,7 @@ describe('hd-keyring', () => {
       const output = await keyring.serialize();
       expect(output.numberOfAccounts).toBe(0);
       expect(output.mnemonic).toStrictEqual(
-        keyring.stringToUint8Array(sampleMnemonic),
+        keyring._stringToUint8Array(sampleMnemonic),
       );
     });
   });
@@ -228,7 +228,7 @@ describe('hd-keyring', () => {
       expect(accountsSecondCheck[1]).toStrictEqual(secondAcct);
       expect(accountsSecondCheck).toHaveLength(2);
       const serialized = await keyring.serialize();
-      expect(keyring.uint8ArrayToString(serialized.mnemonic)).toStrictEqual(
+      expect(keyring._uint8ArrayToString(serialized.mnemonic)).toStrictEqual(
         sampleMnemonic,
       );
     });


### PR DESCRIPTION
Several utility methods were introduced as part of the transition to a new `bip39` implementation: https://github.com/MetaMask/eth-hd-keyring/pull/67.

They should be marked private with a preceding underscore.