### PR TITLE
Revert mnemonic serialization format

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,8 +80,13 @@ class HdKeyring {
   }
 
   serialize() {
+    const mnemonicAsString = this._uint8ArrayToString(this.mnemonic);
+    const uint8ArrayMnemonic = new TextEncoder('utf-8').encode(
+      mnemonicAsString,
+    );
+
     return Promise.resolve({
-      mnemonic: this._mnemonicToUint8Array(this.mnemonic),
+      mnemonic: Array.from(uint8ArrayMnemonic),
       numberOfAccounts: this._wallets.length,
       hdPath: this.hdPath,
     });

--- a/test/index.js
+++ b/test/index.js
@@ -199,21 +199,24 @@ describe('hd-keyring', () => {
     });
 
     it('serializes mnemonic passed in as a string to an array of utf8 encoded bytes', async () => {
+      // keyring is instantiated with `sampleMnemonic` which is passed in as a string in the `beforeEach` block
       const output = await keyring.serialize();
-      expect(Buffer.from(output.mnemonic).toString()).toStrictEqual(
-        sampleMnemonic,
-      );
+      // this Buffer.from(...).toString() is the method of converting from an array of utf8 encoded bytes back to a string
+      const mnemonicAsString = Buffer.from(output.mnemonic).toString();
+      expect(mnemonicAsString).toStrictEqual(sampleMnemonic);
     });
 
     it('serializes mnemonic passed in as a an array of utf8 encoded bytes in the same format', async () => {
       const uint8Array = new TextEncoder('utf-8').encode(sampleMnemonic);
-      const mnemonicAsArryOfBytes = Array.from(uint8Array);
+      const mnemonicAsArrayOfUtf8EncodedBytes = Array.from(uint8Array);
       keyring = new HdKeyring({
-        mnemonic: mnemonicAsArryOfBytes,
+        mnemonic: mnemonicAsArrayOfUtf8EncodedBytes,
       });
 
       const output = await keyring.serialize();
-      expect(Buffer.from(output.mnemonic).toString()).toStrictEqual(
+      // this Buffer.from(...).toString() is the method of converting from an array of utf8 encoded bytes back to a string
+      const mnemonicAsString = Buffer.from(output.mnemonic).toString();
+      expect(mnemonicAsString).toStrictEqual(
         sampleMnemonic,
       );
     });

--- a/test/index.js
+++ b/test/index.js
@@ -216,9 +216,7 @@ describe('hd-keyring', () => {
       const output = await keyring.serialize();
       // this Buffer.from(...).toString() is the method of converting from an array of utf8 encoded bytes back to a string
       const mnemonicAsString = Buffer.from(output.mnemonic).toString();
-      expect(mnemonicAsString).toStrictEqual(
-        sampleMnemonic,
-      );
+      expect(mnemonicAsString).toStrictEqual(sampleMnemonic);
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -182,33 +182,39 @@ describe('hd-keyring', () => {
   });
 
   describe('#serialize mnemonic.', () => {
-    it('serializes mnemonic stored as a buffer to a Uint8Array', async () => {
-      keyring.mnemonic = oldMMForkBIP39.generateMnemonic();
-      const mnemonicAsUint8Array = keyring._stringToUint8Array(
-        keyring.mnemonic.toString(),
+    beforeEach(() => {
+      keyring = new HdKeyring({
+        mnemonic: sampleMnemonic,
+      });
+    });
+
+    it('serializes the mnemonic in the same format as previous version (an array of utf8 encoded bytes)', async () => {
+      // uses previous version of eth-hd-keyring to ensure backwards compatibility
+      const oldHDKeyring = new OldHdKeyring({ mnemonic: sampleMnemonic });
+      const { mnemonic: oldKeyringSerializedMnemonic } =
+        await oldHDKeyring.serialize();
+
+      const output = await keyring.serialize();
+      expect(output.mnemonic).toStrictEqual(oldKeyringSerializedMnemonic);
+    });
+
+    it('serializes mnemonic passed in as a string to an array of utf8 encoded bytes', async () => {
+      const output = await keyring.serialize();
+      expect(Buffer.from(output.mnemonic).toString()).toStrictEqual(
+        sampleMnemonic,
       );
-      const output = await keyring.serialize();
-      expect(output.numberOfAccounts).toBe(0);
-      expect(output.mnemonic).toStrictEqual(mnemonicAsUint8Array);
     });
 
-    it('serializes keyring data with mnemonic stored as a Uint8Array', async () => {
-      keyring.generateRandomMnemonic();
-      const { mnemonic } = keyring;
-      const hdpath = keyring.hdPath;
-      keyring.addAccounts(1);
-      const output = await keyring.serialize();
-      expect(output.numberOfAccounts).toBe(1);
-      expect(output.hdPath).toStrictEqual(hdpath);
-      expect(output.mnemonic).toStrictEqual(mnemonic);
-    });
+    it('serializes mnemonic passed in as a an array of utf8 encoded bytes in the same format', async () => {
+      const uint8Array = new TextEncoder('utf-8').encode(sampleMnemonic);
+      const mnemonicAsArryOfBytes = Array.from(uint8Array);
+      keyring = new HdKeyring({
+        mnemonic: mnemonicAsArryOfBytes,
+      });
 
-    it('serializes mnemonic stored as a string', async () => {
-      keyring.mnemonic = sampleMnemonic;
       const output = await keyring.serialize();
-      expect(output.numberOfAccounts).toBe(0);
-      expect(output.mnemonic).toStrictEqual(
-        keyring._stringToUint8Array(sampleMnemonic),
+      expect(Buffer.from(output.mnemonic).toString()).toStrictEqual(
+        sampleMnemonic,
       );
     });
   });
@@ -228,7 +234,7 @@ describe('hd-keyring', () => {
       expect(accountsSecondCheck[1]).toStrictEqual(secondAcct);
       expect(accountsSecondCheck).toHaveLength(2);
       const serialized = await keyring.serialize();
-      expect(keyring._uint8ArrayToString(serialized.mnemonic)).toStrictEqual(
+      expect(Buffer.from(serialized.mnemonic).toString()).toStrictEqual(
         sampleMnemonic,
       );
     });


### PR DESCRIPTION
Per @Gudahtt 's [here](https://github.com/MetaMask/metamask-extension/pull/17056#issuecomment-1384165936) we want to revert the serialization format from `Uint8Arrays` because they don't serialize nicely to JSON and we want to avoid any possible issues that arise there, back to an untyped array.

This format was previously changed [here](https://github.com/MetaMask/eth-hd-keyring/pull/67) and released with `v5.0.0`