### PR TITLE
Delete `.yarnrc` file

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-ignore-scripts true


### PR DESCRIPTION
This file has not been used since the Yarn v3 migration in https://github.com/MetaMask/eth-hd-keyring/pull/72. It was accidentally left behind.