### PR TITLE
chore!: deprecate + notice about monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # HD Keyring
 
+> [!WARNING]
+> This package has been moved into a
+> [new monorepo](https://github.com/MetaMask/accounts/tree/main/packages/keyring-eth-hd).
+> This repository is no longer in use, and pull requests will no longer be accepted.
+
 A simple JS class wrapped around [ethereumjs-wallet](https://github.com/ethereumjs/ethereumjs-wallet) designed to expose an interface common to many different signing strategies, to be used in a `KeyringController`, like is being used in [MetaMask](https://metamask.io/)
 
 ## Installation


### PR DESCRIPTION
Everything has now been moved to the [new monorepo](https://github.com/MetaMask/accounts). So it's time to deprecate this repo.